### PR TITLE
Typography: Manrope SemiBold headings + Inter Regular body

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -68,7 +68,7 @@ format:
       - text: |
           <link rel="preconnect" href="https://fonts.googleapis.com">
           <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-          <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;0,6..72,700;1,6..72,400&display=swap" rel="stylesheet">
+          <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Manrope:wght@600;700;800&display=swap" rel="stylesheet">
           <style>
             .navbar-title { background: none; -webkit-text-fill-color: initial; }
           </style>

--- a/docs/about.html
+++ b/docs/about.html
@@ -71,7 +71,7 @@ ul.task-list li input[type="checkbox"] {
 }</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
-<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;0,6..72,700;1,6..72,400&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=Manrope:wght@600;700;800&amp;display=swap" rel="stylesheet">
 <style>
   .navbar-title { background: none; -webkit-text-fill-color: initial; }
 </style>

--- a/docs/articles.html
+++ b/docs/articles.html
@@ -71,7 +71,7 @@ ul.task-list li input[type="checkbox"] {
 }</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
-<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;0,6..72,700;1,6..72,400&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=Manrope:wght@600;700;800&amp;display=swap" rel="stylesheet">
 <style>
   .navbar-title { background: none; -webkit-text-fill-color: initial; }
 </style>

--- a/docs/articles/baby_steps_for_causal_discovery/baby_steps_for_causal_discovery.html
+++ b/docs/articles/baby_steps_for_causal_discovery/baby_steps_for_causal_discovery.html
@@ -112,7 +112,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <script src="https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed-amd.js" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
-<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;0,6..72,700;1,6..72,400&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=Manrope:wght@600;700;800&amp;display=swap" rel="stylesheet">
 <style>
   .navbar-title { background: none; -webkit-text-fill-color: initial; }
 </style>

--- a/docs/articles/bayesian_models_and_risk_optimization/bayesian_models_and_risk_optimization.html
+++ b/docs/articles/bayesian_models_and_risk_optimization/bayesian_models_and_risk_optimization.html
@@ -112,7 +112,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <script src="https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed-amd.js" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
-<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;0,6..72,700;1,6..72,400&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=Manrope:wght@600;700;800&amp;display=swap" rel="stylesheet">
 <style>
   .navbar-title { background: none; -webkit-text-fill-color: initial; }
 </style>

--- a/docs/articles/decision_making_under_contradictions/decision_making_under_contradictions.html
+++ b/docs/articles/decision_making_under_contradictions/decision_making_under_contradictions.html
@@ -108,7 +108,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
-<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;0,6..72,700;1,6..72,400&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=Manrope:wght@600;700;800&amp;display=swap" rel="stylesheet">
 <style>
   .navbar-title { background: none; -webkit-text-fill-color: initial; }
 </style>

--- a/docs/articles/from_experiments_to_priors/from_experiments_to_priors.html
+++ b/docs/articles/from_experiments_to_priors/from_experiments_to_priors.html
@@ -112,7 +112,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <script src="https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed-amd.js" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
-<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;0,6..72,700;1,6..72,400&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=Manrope:wght@600;700;800&amp;display=swap" rel="stylesheet">
 <style>
   .navbar-title { background: none; -webkit-text-fill-color: initial; }
 </style>

--- a/docs/articles/nomore_experiments_without_causality/nomore_experiments_without_causality.html
+++ b/docs/articles/nomore_experiments_without_causality/nomore_experiments_without_causality.html
@@ -112,7 +112,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <script src="https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed-amd.js" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
-<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;0,6..72,700;1,6..72,400&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=Manrope:wght@600;700;800&amp;display=swap" rel="stylesheet">
 <style>
   .navbar-title { background: none; -webkit-text-fill-color: initial; }
 </style>

--- a/docs/articles/placebo_bayesian_quasi_experiments/placebo_bayesian_quasi_experiments.html
+++ b/docs/articles/placebo_bayesian_quasi_experiments/placebo_bayesian_quasi_experiments.html
@@ -109,7 +109,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
-<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;0,6..72,700;1,6..72,400&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=Manrope:wght@600;700;800&amp;display=swap" rel="stylesheet">
 <style>
   .navbar-title { background: none; -webkit-text-fill-color: initial; }
 </style>

--- a/docs/index.html
+++ b/docs/index.html
@@ -71,7 +71,7 @@ ul.task-list li input[type="checkbox"] {
 }</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
-<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;0,6..72,700;1,6..72,400&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=Manrope:wght@600;700;800&amp;display=swap" rel="stylesheet">
 <style>
   .navbar-title { background: none; -webkit-text-fill-color: initial; }
 </style>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://cetagostini.github.io/talks.html</loc>
-    <lastmod>2026-07-05T17:15:18.066Z</lastmod>
+    <lastmod>2026-07-05T17:17:41.062Z</lastmod>
   </url>
   <url>
     <loc>https://cetagostini.github.io/articles/placebo_bayesian_quasi_experiments/placebo_bayesian_quasi_experiments.html</loc>
@@ -18,11 +18,11 @@
   </url>
   <url>
     <loc>https://cetagostini.github.io/articles.html</loc>
-    <lastmod>2026-07-05T16:53:39.722Z</lastmod>
+    <lastmod>2026-07-05T17:17:41.058Z</lastmod>
   </url>
   <url>
     <loc>https://cetagostini.github.io/about.html</loc>
-    <lastmod>2026-07-05T16:41:44.097Z</lastmod>
+    <lastmod>2026-07-05T17:17:41.058Z</lastmod>
   </url>
   <url>
     <loc>https://cetagostini.github.io/articles/baby_steps_for_causal_discovery/baby_steps_for_causal_discovery.html</loc>
@@ -38,6 +38,6 @@
   </url>
   <url>
     <loc>https://cetagostini.github.io/index.html</loc>
-    <lastmod>2026-07-05T17:08:23.262Z</lastmod>
+    <lastmod>2026-07-05T17:17:41.062Z</lastmod>
   </url>
 </urlset>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -35,17 +35,17 @@
 body {
   background: var(--bg);
   color: var(--ink);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Inter,
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
                "Helvetica Neue", Arial, sans-serif;
   font-size: 1.02rem;
   line-height: 1.65;
 }
 
 h1, h2, h3, h4, .navbar-title, .hero-section h1, .hero-section h2,
-.experience-title, .skills-category h2, .talks h3, .article-preview h3 {
-  font-family: "Newsreader", "Source Serif 4", Georgia, "Times New Roman", serif;
+.hero-section .hero-name, .experience-title, .skills-category h2, .talks h3, .article-preview h3 {
+  font-family: "Manrope", -apple-system, "Segoe UI", sans-serif;
   color: var(--brown-strong);
-  font-weight: 700;
+  font-weight: 600;
   letter-spacing: -0.01em;
 }
 
@@ -92,8 +92,8 @@ p, li { color: var(--ink); }
   padding: .65rem 1rem;
 }
 .navbar-brand, .navbar-title {
-  font-family: "Newsreader", Georgia, serif;
-  font-weight: 700;
+  font-family: "Manrope", -apple-system, sans-serif;
+  font-weight: 600;
   font-size: 1.2rem;
   color: var(--brown-strong) !important;
   background: none !important;
@@ -155,12 +155,12 @@ p, li { color: var(--ink); }
 .hero-section .title,
 .hero-section .hero-name {
   font-size: clamp(2.1rem, 5vw, 3rem);
-  font-weight: 700; color: var(--ink); margin: 0 !important; line-height: 1.1;
+  font-weight: 600; color: var(--ink); margin: 0 !important; line-height: 1.1;
 }
 .hero-section .hero-subtitle {
-  font-family: "Newsreader", Georgia, serif;
+  font-family: "Inter", -apple-system, sans-serif;
   font-size: clamp(1.15rem, 2.4vw, 1.5rem);
-  color: var(--brown-strong); margin: 0 0 1rem; font-weight: 500;
+  color: var(--brown-strong); margin: 0 0 1rem; font-weight: 400;
 }
 .hero-section .hero-subtitle p { margin: 0; }
 .quarto-title-block:empty { display: none; }
@@ -382,7 +382,7 @@ h3 + em { display: block; margin-bottom: 1em; color: var(--ink-muted); font-size
 .video-card:hover .video-play { transform: scale(1.08); background: var(--green); }
 .video-card:hover .video-play::before { border-left-color: #fff; }
 .video-card-body { padding: .8rem .95rem; }
-.video-card-title { display: block; font-family: "Newsreader", Georgia, serif; font-size: 1.05rem; font-weight: 700; margin: 0 0 .15rem; color: var(--brown-strong); }
+.video-card-title { display: block; font-family: "Manrope", -apple-system, sans-serif; font-size: 1.05rem; font-weight: 600; margin: 0 0 .15rem; color: var(--brown-strong); }
 .video-card-date { display: block; font-size: .8rem; color: var(--ink-muted); margin: 0; }
 
 .carousel-nav {
@@ -490,8 +490,8 @@ h3 + em { display: block; margin-bottom: 1em; color: var(--ink-muted); font-size
 .career-dag .cd-node { fill: var(--surface); stroke: var(--green); stroke-width: 2; }
 .career-dag .cd-node-role { fill: var(--green-strong); }
 .career-dag .cd-edge { stroke: var(--brown); stroke-width: 2; fill: none; }
-.career-dag .cd-label { fill: var(--ink); font-family: -apple-system, sans-serif; font-size: 12px; font-weight: 600; }
-.career-dag .cd-sub { fill: var(--ink-muted); font-family: -apple-system, sans-serif; font-size: 10px; }
+.career-dag .cd-label { fill: var(--ink); font-family: "Manrope", sans-serif; font-size: 12px; font-weight: 600; }
+.career-dag .cd-sub { fill: var(--ink-muted); font-family: "Inter", sans-serif; font-size: 10px; }
 
 /* -------------------------------------------------------------------------
    Reduced motion

--- a/docs/talks.html
+++ b/docs/talks.html
@@ -71,7 +71,7 @@ ul.task-list li input[type="checkbox"] {
 }</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
-<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;0,6..72,700;1,6..72,400&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=Manrope:wght@600;700;800&amp;display=swap" rel="stylesheet">
 <style>
   .navbar-title { background: none; -webkit-text-fill-color: initial; }
 </style>

--- a/styles.css
+++ b/styles.css
@@ -35,17 +35,17 @@
 body {
   background: var(--bg);
   color: var(--ink);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Inter,
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
                "Helvetica Neue", Arial, sans-serif;
   font-size: 1.02rem;
   line-height: 1.65;
 }
 
 h1, h2, h3, h4, .navbar-title, .hero-section h1, .hero-section h2,
-.experience-title, .skills-category h2, .talks h3, .article-preview h3 {
-  font-family: "Newsreader", "Source Serif 4", Georgia, "Times New Roman", serif;
+.hero-section .hero-name, .experience-title, .skills-category h2, .talks h3, .article-preview h3 {
+  font-family: "Manrope", -apple-system, "Segoe UI", sans-serif;
   color: var(--brown-strong);
-  font-weight: 700;
+  font-weight: 600;
   letter-spacing: -0.01em;
 }
 
@@ -92,8 +92,8 @@ p, li { color: var(--ink); }
   padding: .65rem 1rem;
 }
 .navbar-brand, .navbar-title {
-  font-family: "Newsreader", Georgia, serif;
-  font-weight: 700;
+  font-family: "Manrope", -apple-system, sans-serif;
+  font-weight: 600;
   font-size: 1.2rem;
   color: var(--brown-strong) !important;
   background: none !important;
@@ -155,12 +155,12 @@ p, li { color: var(--ink); }
 .hero-section .title,
 .hero-section .hero-name {
   font-size: clamp(2.1rem, 5vw, 3rem);
-  font-weight: 700; color: var(--ink); margin: 0 !important; line-height: 1.1;
+  font-weight: 600; color: var(--ink); margin: 0 !important; line-height: 1.1;
 }
 .hero-section .hero-subtitle {
-  font-family: "Newsreader", Georgia, serif;
+  font-family: "Inter", -apple-system, sans-serif;
   font-size: clamp(1.15rem, 2.4vw, 1.5rem);
-  color: var(--brown-strong); margin: 0 0 1rem; font-weight: 500;
+  color: var(--brown-strong); margin: 0 0 1rem; font-weight: 400;
 }
 .hero-section .hero-subtitle p { margin: 0; }
 .quarto-title-block:empty { display: none; }
@@ -382,7 +382,7 @@ h3 + em { display: block; margin-bottom: 1em; color: var(--ink-muted); font-size
 .video-card:hover .video-play { transform: scale(1.08); background: var(--green); }
 .video-card:hover .video-play::before { border-left-color: #fff; }
 .video-card-body { padding: .8rem .95rem; }
-.video-card-title { display: block; font-family: "Newsreader", Georgia, serif; font-size: 1.05rem; font-weight: 700; margin: 0 0 .15rem; color: var(--brown-strong); }
+.video-card-title { display: block; font-family: "Manrope", -apple-system, sans-serif; font-size: 1.05rem; font-weight: 600; margin: 0 0 .15rem; color: var(--brown-strong); }
 .video-card-date { display: block; font-size: .8rem; color: var(--ink-muted); margin: 0; }
 
 .carousel-nav {
@@ -490,8 +490,8 @@ h3 + em { display: block; margin-bottom: 1em; color: var(--ink-muted); font-size
 .career-dag .cd-node { fill: var(--surface); stroke: var(--green); stroke-width: 2; }
 .career-dag .cd-node-role { fill: var(--green-strong); }
 .career-dag .cd-edge { stroke: var(--brown); stroke-width: 2; fill: none; }
-.career-dag .cd-label { fill: var(--ink); font-family: -apple-system, sans-serif; font-size: 12px; font-weight: 600; }
-.career-dag .cd-sub { fill: var(--ink-muted); font-family: -apple-system, sans-serif; font-size: 10px; }
+.career-dag .cd-label { fill: var(--ink); font-family: "Manrope", sans-serif; font-size: 12px; font-weight: 600; }
+.career-dag .cd-sub { fill: var(--ink-muted); font-family: "Inter", sans-serif; font-size: 10px; }
 
 /* -------------------------------------------------------------------------
    Reduced motion


### PR DESCRIPTION
Swap the site typeface from Newsreader (serif) to a clean sans pair:

- **Headings (main):** Manrope SemiBold (600)
- **Body (secondary):** Inter Regular (400)

Both loaded via Google Fonts (`display=swap`). Newsreader fully removed. Updates navbar brand, hero name/subtitle, section titles, experience/skills/talk titles, video-card titles, and career-DAG labels.

Follow-up to the redesign in #46.